### PR TITLE
feat(completion): integrate `codecompanion` plugin and update `blink-cmp` configuration

### DIFF
--- a/config/completion/blink-cmp.nix
+++ b/config/completion/blink-cmp.nix
@@ -3,45 +3,49 @@ let
   inherit (lib.nixvim) listToUnkeyedAttrs mkRaw;
 in
 {
-  plugins.blink-cmp = {
-    enable = true;
-    settings = {
-      completion = {
-        documentation = {
-          auto_show = true;
-        };
-        menu = {
-          min_width = 50;
-          draw = {
-            # We don't need label_description now because label and label_description are already
-            # combined together in label by colorful-menu.nvim.
-            columns = [
-              (listToUnkeyedAttrs [ "kind_icon" ])
-              ((listToUnkeyedAttrs [ "label" ]) // { gap = 1; })
-            ];
+  plugins = {
+    blink-cmp = {
+      enable = true;
+      settings = {
+        sources.per_filetype.codecompanion = [ "codecompanion" ];
 
-            components = {
-              label = {
-                text = mkRaw ''
-                  function (ctx)
-                    return require("colorful-menu").blink_components_text(ctx)
-                  end
-                '';
-                highlight = mkRaw ''
-                  function (ctx)
-                    return require("colorful-menu").blink_components_highlight(ctx)
-                  end
-                '';
+        completion = {
+          documentation = {
+            auto_show = true;
+          };
+          menu = {
+            min_width = 50;
+            draw = {
+              # We don't need label_description now because label and label_description are already
+              # combined together in label by colorful-menu.nvim.
+              columns = [
+                (listToUnkeyedAttrs [ "kind_icon" ])
+                ((listToUnkeyedAttrs [ "label" ]) // { gap = 1; })
+              ];
+
+              components = {
+                label = {
+                  text = mkRaw ''
+                    function (ctx)
+                      return require("colorful-menu").blink_components_text(ctx)
+                    end
+                  '';
+                  highlight = mkRaw ''
+                    function (ctx)
+                      return require("colorful-menu").blink_components_highlight(ctx)
+                    end
+                  '';
+                };
               };
             };
           };
         };
-      };
-      signature = {
-        enabled = true;
+        signature = {
+          enabled = true;
+        };
       };
     };
-  };
 
-  plugins.colorful-menu.enable = true;
+    colorful-menu.enable = true;
+  };
 }

--- a/config/completion/codecompanion.nix
+++ b/config/completion/codecompanion.nix
@@ -1,0 +1,5 @@
+{
+  plugins.codecompanion = {
+    enable = true;
+  };
+}

--- a/config/default.nix
+++ b/config/default.nix
@@ -16,6 +16,7 @@ in
     ./completion/blink-cmp.nix
     ./completion/friendly-snippets.nix
     ./completion/cmp.nix
+    ./completion/codecompanion.nix
     ./completion/copilot.nix
     ./completion/friendly-snippets.nix
     ./completion/lspkind.nix


### PR DESCRIPTION
- Added `codecompanion` plugin with basic enablement in `codecompanion.nix`.
- Updated `blink-cmp.nix` to include `codecompanion` as a source for per-filetype completion.
